### PR TITLE
docs: add agentic development disclosure to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A Rust library for reading, writing, and manipulating MARC bibliographic records, with Python bindings.
 
-**Note:** This project was developed using agentic coding tools ([amp](https://ampcode.com/) and [Claude](https://claude.ai/)) and uses [beads](https://github.com/dchud/beads) for agentic issue tracking. The package has not yet had extensive practical testing by humans and should be considered experimental.
+**Note:** This project was developed using agentic coding tools ([amp](https://ampcode.com/) and [Claude](https://claude.ai/)) and uses [beads](https://github.com/steveyegge/beads) for agentic issue tracking. The package has not yet had extensive practical testing by humans and should be considered experimental.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 A Rust library for reading, writing, and manipulating MARC bibliographic records, with Python bindings.
 
+**Note:** This project was developed using agentic coding tools ([amp](https://ampcode.com/) and [Claude](https://claude.ai/)) and uses [beads](https://github.com/dchud/beads) for agentic issue tracking. The package has not yet had extensive practical testing by humans and should be considered experimental.
+
 ## Features
 
 - Reads and writes ISO 2709 (MARC21) binary format


### PR DESCRIPTION
## Summary
- Adds prominent note to README that this project was developed using agentic coding tools (amp and Claude)
- Mentions the use of beads for agentic issue tracking
- Notes that the package hasn't had extensive human testing and should be considered experimental

Closes #5

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm links to amp, Claude, and beads work

🤖 Generated with [Claude Code](https://claude.com/claude-code)